### PR TITLE
MUL-1942: cd alpine builds

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -4,5 +4,7 @@
 */*.tar
 */*.tar.gz
 */*.zip
+*/*.log
+*/logs/*
 .drone.yml
 .drone/

--- a/.gitignore
+++ b/.gitignore
@@ -4,8 +4,8 @@ cmd/stage
 cmd/multy
 cmd/multy.config
 cmd/btc.cert
-cmd/back-*
-cmd/logs
+*/logs/*
+*/*.log
 cmd/rpc.cert
 cmd/state.json
 cmd/ns-eth/ns-eth

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,39 +1,52 @@
 # Builder image that builds all the multy-back and all node services
 # multyio/multy-back-builder has all dependencies cached
-FROM multyio/multy-back-builder as builder
+# Based on golang:1.9.4
+FROM multyio/multy-back-builder:dev as builder
 
 WORKDIR $GOPATH/src/github.com/Multy-io/Multy-back
-# Build an image from sources of local directory
+# Build an image from sources of local directory.
 COPY . $GOPATH/src/github.com/Multy-io/Multy-back
 RUN go get -v -d ./...
-RUN make build
+RUN CC=musl-gcc make build -B
 
 # Base image for all images with executable application
+# Sets important arguments and labels.
+# As for Dec 3 2018 alpine:3.8 had no known vulnerabilities
+# golang:1.10-alpine3.8
 FROM alpine:3.8 as base
 # Common stuff to put into all derived containers
+ONBUILD LABEL org.label-schema.schema-version = "1.0"
+ONBUILD LABEL org.label-schema.url = "http://multy.io"
+ONBUILD LABEL org.label-schema.vcs-url = "https://github.com//multy-io/multy-back"
 ONBUILD ARG BUILD_DATE
 ONBUILD ARG GIT_COMMIT
 ONBUILD ARG GIT_BRANCH
 ONBUILD ARG GIT_TAG
 ONBUILD LABEL org.label-schema.build-date="$BUILD_DATE"
 ONBUILD LABEL org.label-schema.git-branch="$GIT_BRANCH"
-ONBUILD LABEL org.label-schema.git-commit="$GIT_COMMIT"
-ONBUILD LABEL org.label-schema.git-tag="$GIT_TAG"
+ONBUILD LABEL org.label-schema.vcs-ref="$GIT_COMMIT"
+ONBUILD LABEL org.label-schema.version="$GIT_TAG"
 
 
 FROM base as multy-back
+LABEL org.label-schema.name = "Multy Back"
 WORKDIR /multy
 COPY --from=builder /go/src/github.com/Multy-io/Multy-back/cmd/multy-back/multy-back /multy/multy-back
-ENTRYPOINT /multy/multy-back
+RUN /multy/multy-back --CanaryTest=true
+ENTRYPOINT ["/multy/multy-back"]
 
 
 FROM base as multy-btc-node-service
+LABEL org.label-schema.name = "Multy BTC Node service"
 WORKDIR /multy
 COPY --from=builder /go/src/github.com/Multy-io/Multy-back/cmd/ns-btc/ns-btc /multy/ns-btc
-ENTRYPOINT /multy/ns-btc
+RUN /multy/ns-btc --CanaryTest=true
+ENTRYPOINT ["/multy/ns-btc"]
 
 
 FROM base as multy-eth-node-service
+LABEL org.label-schema.name = "Multy ETH Node service"
 WORKDIR /multy
 COPY --from=builder /go/src/github.com/Multy-io/Multy-back/cmd/ns-eth/ns-eth /multy/ns-eth
-ENTRYPOINT /multy/ns-eth
+RUN /multy/ns-eth --CanaryTest=true
+ENTRYPOINT ["/multy/ns-eth"]

--- a/Dockerfile_multy-back-builder
+++ b/Dockerfile_multy-back-builder
@@ -1,0 +1,37 @@
+# golang:1-alpine3.8 can't be used as base image since apline-based gcc
+# fails to compile github.com/ethereum/go-ethereum/crypto/secp256k1/secp256.go
+FROM golang:1.9.4 as multy-back-builder
+LABEL org.label-schema.schema-version = "1.0"
+LABEL org.label-schema.url = "http://multy.io"
+LABEL org.label-schema.vcs-url = "https://github.com//multy-io/multy-back"
+LABEL org.label-schema.name = "Multy Back builder image"
+LABEL org.label-schema.description = "Collection of cached dependencies and build tools to simplify and speed up building multy-back on both CI/CD server and machine."
+LABEL org.label-schema.usage = "Use as a base image: 'FROM multyio/multy-back-builder'"
+
+ARG BUILD_DATE
+ARG GIT_COMMIT
+ARG GIT_BRANCH
+ARG GIT_TAG
+LABEL org.label-schema.build-date="$BUILD_DATE"
+LABEL org.label-schema.git-branch="$GIT_BRANCH"
+LABEL org.label-schema.vcs-ref="$GIT_COMMIT"
+LABEL org.label-schema.version="$GIT_TAG"
+
+# Get a version of multy-back from current sources, fetch all dependencies, clear multy-back sources
+COPY . $GOPATH/src/github.com/Multy-io/Multy-back
+WORKDIR $GOPATH/src/github.com/Multy-io/Multy-back
+
+# Download all dependencies of the multy-back
+RUN go get -v ./...
+
+# Get, build and install musl-gcc - a compiler wrapper and libc implementation 
+# that allows static builds with cgo to run in alpine-based dockers.
+RUN curl http://www.musl-libc.org/releases/musl-1.1.20.tar.gz | tar -xz \
+    && cd ./musl-1.1.20 \
+    && ./configure --prefix=/usr && make && make install
+
+# Check that project can be built and binaries appear to work Ok on this platform.
+RUN make build -B && make canary-test && make test
+
+# Cleanup
+RUN rm -rf ./*

--- a/Makefile
+++ b/Makefile
@@ -5,19 +5,10 @@ COMMIT = $(shell git rev-parse --short HEAD)
 BUILDTIME = $(shell date +%Y-%m-%dT%T%z)
 LASTTAG = $(shell git describe --tags --abbrev=0 --dirty)
 GOPATH = $(shell echo "$$GOPATH")
-LD_OPTS = -ldflags="-X main.branch=${BRANCH} -X main.commit=${COMMIT} -X main.lasttag=${LASTTAG} -X main.buildtime=${BUILDTIME} -w "
+LD_OPTS = -ldflags="-X main.branch=${BRANCH} -X main.commit=${COMMIT} -X main.lasttag=${LASTTAG} -X main.buildtime=${BUILDTIME} -linkmode=external -w -s"
 
 # List of all binary targets we expect from make to produce
 TARGETS=cmd/multy-back/multy-back cmd/ns-btc/ns-btc cmd/ns-eth/ns-eth
-
-# List of all docker images to build and tag
-DOCKER_IMAGES=multy-back multy-btc-node-service multy-eth-node-service
-
-# The default tag, used for building images, to remove ambigulty of ':latest'
-DOCKER_BUILD_TAG=$(COMMIT)
-# The tag image is pushed with
-DOCKER_TAG?=$(DOCKER_BUILD_TAG)
-DOCKERHUB_ACCOUNT=multyio
 
 TARGET_OS=
 TARGET_ARCH=
@@ -26,8 +17,12 @@ all: proto build test
 
 all-with-deps: setup deps dist
 
-run:
-	cd cmd && ./$(NAME) && ../
+run: build
+	$(foreach target,$(TARGETS), ./$(target)&) true
+
+# Just test that built binaries can be run on this system.
+canary-test: build
+	$(foreach target,$(TARGETS), echo "Canary-testing $(target)" && ./$(target) --CanaryTest=true;) echo "Canary done"
 
 # memprofiler:
 # 	cd $(GOPATH)/src/github.com/Multy-io/Multy-back/cmd && rm -rf multy && cd .. && make build  && cd cmd && ./$(NAME) -memprofile mem.prof && ../
@@ -50,9 +45,48 @@ $(TARGETS):
 	GOOS=$(TARGET_OS) GOARCH=$(TARGET_ARCH) go build $(LD_OPTS) -o $(@F) . && \
 	cd -
 
+.PHONY: test
+test:
+	go test ./...
+
+proto-btc-ns:
+	cd ./ns-btc-protobuf && protoc --go_out=plugins=grpc:. *.proto
+	cd ./ns-eth-protobuf && protoc --go_out=plugins=grpc:. *.proto
+
+proto: proto-btc-ns
+
+# Show to-do items per file.
+todo:
+	@grep \
+		--exclude-dir=vendor \
+		--exclude-dir=node_modules \
+		--exclude=Makefile \
+		--text \
+		--color \
+		-nRo -E ' TODO:.*|SkipNow|nolint:.*' .
+.PHONY: todo
+
+# 'true' is to avoid failing the rule if any target file does not exist.
+clean:
+	$(foreach target,$(TARGETS), rm -v ./$(target);) true
+
+#################################################################################
+# Docker-related stuff goes beyond this line
+#################################################################################
+
+# List of all docker images to build and tag
+DOCKER_IMAGES=multy-back multy-btc-node-service multy-eth-node-service
+
+# The default tag, used for building images, to remove ambigulty of ':latest'
+DOCKER_BUILD_TAG=$(COMMIT)
+# The tag image is pushed with
+DOCKER_TAG?=$(DOCKER_BUILD_TAG)
+DOCKERHUB_ACCOUNT=multyio
+
 .PHONY: docker-build-images
 .PHONY: docker-retag-images
 .PHONY: docker-push-images
+.PHONY: docker-build-builder-image
 
 docker-all: docker-build-images docker-retag-images docker-push-images
 
@@ -76,23 +110,24 @@ docker-retag-images:
 docker-push-images:
 	$(foreach docker_image,$(DOCKER_IMAGES), docker push $(DOCKERHUB_ACCOUNT)/$(docker_image):$(DOCKER_TAG);)
 
-.PHONY: test
-test:
-	go test ./...
+docker-test-images: docker-build-images
+	$(foreach docker_image,$(DOCKER_IMAGES), docker run $(DOCKERHUB_ACCOUNT)/$(docker_image):$(DOCKER_TAG);)
 
-proto-btc-ns:
-	cd ./ns-btc-protobuf && protoc --go_out=plugins=grpc:. *.proto
-	cd ./ns-eth-protobuf && protoc --go_out=plugins=grpc:. *.proto
+# Special case: a builder image, please note that it is not automatically retagged nor pushed to avoid 
+# accidentally breaking the builds on both CI/CD and developer machine.
+# Thus setting making a release tag and pushing that to docker hub must be done manually and with extra care
+docker-build-builder-image:
+	docker build --target multy-back-builder \
+		--file Dockerfile_multy-back-builder \
+		--tag $(DOCKERHUB_ACCOUNT)/multy-back-builder:$(DOCKER_BUILD_TAG) \
+		--build-arg BUILD_DATE=$(BUILDTIME) \
+		--build-arg GIT_COMMIT=$(COMMIT) \
+		--build-arg GIT_BRANCH=$(BRANCH) \
+		--build-arg GIT_TAG=$(LASTTAG) \
+		.
 
-proto: proto-btc-ns
+docker-retag-builder-image:
+	docker tag $(DOCKERHUB_ACCOUNT)/multy-back-builder:$(DOCKER_BUILD_TAG) $(DOCKERHUB_ACCOUNT)/multy-back-builder:$(DOCKER_TAG)
 
-# Show to-do items per file.
-todo:
-	@grep \
-		--exclude-dir=vendor \
-		--exclude-dir=node_modules \
-		--exclude=Makefile \
-		--text \
-		--color \
-		-nRo -E ' TODO:.*|SkipNow|nolint:.*' .
-.PHONY: todo
+docker-push-builder-image:
+	docker push $(DOCKERHUB_ACCOUNT)/multy-back-builder:$(DOCKER_TAG)

--- a/cmd/multy-back/main.go
+++ b/cmd/multy-back/main.go
@@ -17,15 +17,18 @@ import (
 )
 
 var (
-	log = slf.WithContext("main")
+	log = slf.WithContext("multy-back")
 
+	// Set externaly during build
 	branch    string
 	commit    string
-	buildtime string
 	lasttag   string
+	buildtime string
+
 	// TODO: add all default params
 	globalOpt = multy.Configuration{
-		Name: "my-test-back",
+		CanaryTest: false,
+		Name:       "my-test-back",
 		Database: store.Conf{
 			Address:             "localhost:27017",
 			DBUsers:             "userDB-test",
@@ -43,13 +46,19 @@ var (
 )
 
 func main() {
-	config.ReadGlobalConfig(&globalOpt, "multy configuration")
-	log.Infof("CONFIGURATION=%+v", globalOpt.SupportedNodes)
-
+	log.Info("============================================================")
 	log.Infof("branch: %s", branch)
 	log.Infof("commit: %s", commit)
 	log.Infof("build time: %s", buildtime)
 	log.Infof("tag: %s", lasttag)
+
+	config.ReadGlobalConfig(&globalOpt, "multy configuration")
+	log.Infof("CONFIGURATION=%+v", globalOpt.SupportedNodes)
+
+	if globalOpt.CanaryTest == true {
+		log.Info("This is a CanaryTest run, quitting immediatelly...")
+		return
+	}
 
 	sc := store.ServerConfig{
 		BranchName: branch,

--- a/cmd/ns-btc/main.go
+++ b/cmd/ns-btc/main.go
@@ -16,24 +16,38 @@ import (
 )
 
 var (
-	log = slf.WithContext("main")
+	log = slf.WithContext("ns-btc")
 
+	// Set externaly during build
 	branch    string
 	commit    string
+	lasttag   string
 	buildtime string
 )
 
 // TODO: add all default params
 var globalOpt = nsbtc.Configuration{
-	Name: "my-test-back",
+	CanaryTest: false,
+	Name:       "my-test-back",
 }
 
 func main() {
-	config.ReadGlobalConfig(&globalOpt, "multy configuration")
-	log.Infof("CONFIGURATION=%+v", globalOpt)
+	log.Info("============================================================")
+	log.Info("Node service BTC starting")
 	log.Infof("branch: %s", branch)
 	log.Infof("commit: %s", commit)
 	log.Infof("build time: %s", buildtime)
+
+	log.Info("Reading configuration...")
+
+	config.ReadGlobalConfig(&globalOpt, "multy configuration")
+	log.Infof("CONFIGURATION=%+v", globalOpt)
+
+	if globalOpt.CanaryTest == true {
+		log.Info("This is a CanaryTest run, quitting immediatelly...")
+		return
+	}
+
 	globalOpt.ServiceInfo = store.ServiceInfo{
 		Branch:    branch,
 		Commit:    commit,

--- a/cmd/ns-eth/main.go
+++ b/cmd/ns-eth/main.go
@@ -20,25 +20,38 @@ import (
 )
 
 var (
-	log       = slf.WithContext("main")
+	log = slf.WithContext("ns-eth")
+
+	// Set externaly during build
 	branch    string
 	commit    string
+	lasttag   string
 	buildtime string
 
 	memprofile = flag.String("memprofile", "", "write memory profile to `file`")
 )
 
 var globalOpt = ns.Configuration{
-	Name: "eth-node-service",
+	CanaryTest: false,
+	Name:       "eth-node-service",
 }
 
 func main() {
-	config.ReadGlobalConfig(&globalOpt, "multy configuration")
-	log.Infof("CONFIGURATION=%+v", globalOpt)
-
+	log.Info("============================================================")
+	log.Info("Node service ETH starting")
 	log.Infof("branch: %s", branch)
 	log.Infof("commit: %s", commit)
 	log.Infof("build time: %s", buildtime)
+
+	log.Info("Reading configuration...")
+	config.ReadGlobalConfig(&globalOpt, "multy configuration")
+	log.Infof("CONFIGURATION=%+v", globalOpt)
+
+	if globalOpt.CanaryTest == true {
+		log.Info("This is a CanaryTest run, quitting immediatelly...")
+		return
+	}
+
 	globalOpt.ServiceInfo = store.ServiceInfo{
 		Branch:    branch,
 		Commit:    commit,

--- a/config.go
+++ b/config.go
@@ -13,6 +13,7 @@ import (
 
 // Configuration is a struct with all service options
 type Configuration struct {
+	CanaryTest        bool
 	Name              string
 	Database          store.Conf
 	SocketioAddr      string

--- a/ns-btc/config.go
+++ b/ns-btc/config.go
@@ -9,6 +9,7 @@ import "github.com/Multy-io/Multy-back/store"
 
 // Configuration is a struct with all service options
 type Configuration struct {
+	CanaryTest          bool
 	Name                string
 	GrpcPort            string
 	BTCSertificate      string

--- a/ns-eth/config.go
+++ b/ns-eth/config.go
@@ -11,6 +11,7 @@ import (
 
 // Configuration is a struct with all service options
 type Configuration struct {
+	CanaryTest      bool
 	Name            string
 	GrpcPort        string
 	MultisigFactory string


### PR DESCRIPTION
* Fixed building and packaging docker images for alpine with musl static library.
* Updated startup banners for node services and multy back.
* Separate Dockerfile for multy-back-builder image: Dockerfile_multy-back-builder
* Using CanaryTest mode for multy-back and ns to verify that images was built Ok.